### PR TITLE
fix(/src/js/zmain.js): Typo

### DIFF
--- a/src/js/zmain.js
+++ b/src/js/zmain.js
@@ -64,9 +64,10 @@
           break;
       }
     }
+    //use esc key to close search panel: typo fixed
     if($('.search-form').hasClass('active')){
       switch(e.key) {
-        case "Esc":
+        case "Escape":
           $('.icon-remove-sign').trigger('click');
           break;
       }


### PR DESCRIPTION
'Escape' key should be used to close search panel, 'Esc' doesn't work. Minus mistake.