### PR TITLE
fix(sidebar): search link not clickable

### DIFF
--- a/_includes/menu-search.html
+++ b/_includes/menu-search.html
@@ -55,7 +55,7 @@
 
     <ul>
       <li><span class="counter-menu">g</span><svg viewBox="0 0 50 50" class="icon-arrow-menu"><use xlink:href="#icon-right-arrow"></use></svg><a title="Show my projects on GitHub"  target="_blank" href="http://github.com/{{site.github_username}}" class="search">github</a></li>
-      <li><span class="counter-menu">s</span><svg viewBox="0 0 50 50" class="icon-arrow-menu"><use xlink:href="#icon-right-arrow"></use></svg><a  title="Search for a post" class="search">search</a></li>
+      <li><span class="counter-menu">s</span><svg viewBox="0 0 50 50" class="icon-arrow-menu"><use xlink:href="#icon-right-arrow"></use></svg><a id="searching" title="Search for a post" class="search">search</a></li>
       <li><span class="counter-menu">t</span><svg viewBox="0 0 50 50" class="icon-arrow-menu"><use xlink:href="#icon-right-arrow"></use></svg><a title="Follow me in Twitter" target="_blank" href="http://twitter.com/{{site.twitter_username}}">twitter</a></li>
     </ul>
   </nav>

--- a/src/js/zmain.js
+++ b/src/js/zmain.js
@@ -21,6 +21,13 @@
         return false;
     }
   };
+  
+  // Search panel mouse click event suppport
+  $('#searching').click(function(){
+    $('#fade').trigger('click');
+    $("#search").trigger('click');
+  })
+  
   //Keys
   $(document).keydown(function(e){
     // console.log(e.key);


### PR DESCRIPTION
I found that the search link on sidebar was no response after mouse click. I guess the search link mouse click event is not handled.

A new id (*#searching*) is added to __menu-search.html__, for mouse click event.