### PR TITLE
fix(/src/js/zmain.js): extra char search input

### DIFF
--- a/src/js/zmain.js
+++ b/src/js/zmain.js
@@ -72,6 +72,17 @@
       }
     }
   });
+  
+  //Key release
+  //Fix : extra character 's' is entered to the input field when switching to the search form by using keypress
+  $(document).keyup(function(e){
+    if($('.search-form').hasClass('active')){
+      $(".search-form").find('input').focus();
+    }else{
+      $(".search-form").find('input').blur();
+    }
+  });
+  
   // Search
   var bs = {
     close: $(".icon-remove-sign"),
@@ -83,7 +94,8 @@
   bs.dothis.on('click', function() {
     $('.search-wrapper').toggleClass('active');
     bs.searchform.toggleClass('active');
-    bs.searchform.find('input').focus();
+    // Only focus the form after key release, prvent the character 's' entered immediately after key enter
+    //bs.searchform.find('input').focus();     
     bs.canvas.toggleClass('search-overlay');
     $('.search-field').simpleJekyllSearch();
   });


### PR DESCRIPTION
Problem: The keydown() event trigger click() + focus(), causing extra character 's' captured to the input field. The focus() event should delay and put into keyup() event. 

Commit: Every keyup() trigger if search panel is active, then focus() to its input field, else blur() to unfocus.

Another option is clear the input field each time when switching to the search panel, but the previous record entered by user cannot be kept, so I think the first approach is better.